### PR TITLE
Changes ubuntu version from artful to bionic

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 # Set environment variables
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Dockerfile was crashing because artful's repos weren't updated. The docker installation works now with Ubuntu 18.04 LTS (Bionic Beaver)